### PR TITLE
Downgrading Deploy Action to prevent issues when renaming or deleting folders

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
 
     # Update files on the webserver using FTP.
     - name: Sync Files on Web Server
-      uses: SamKirkland/FTP-Deploy-Action@4.1.0
+      uses: SamKirkland/FTP-Deploy-Action@4.0.0
       with:
         server: ${{ secrets.SERVER_NAME }}
         username: ${{ secrets.FTP_USER }}


### PR DESCRIPTION
# Downgrading Deploy Actions
This downgrades the version of the FTP deploy actions plugin due to a bug when renaming or deleting folders. More documentation on this bug can be found [on this github issue](https://github.com/SamKirkland/FTP-Deploy-Action/issues/220)

# Category
- [ ] One-Month Project Submission
- [x] Bug Fix

